### PR TITLE
fix AlgorithmName

### DIFF
--- a/JwtManager/RsJwt.cs
+++ b/JwtManager/RsJwt.cs
@@ -110,7 +110,7 @@ namespace JwtManager
         {
             get
             {
-                return "SHA" + KeySize.ToString();
+                return "SHA" + (int)KeySize;
             }
         }
 


### PR DESCRIPTION
When trying to use this class (in an old .Net 4.0 project), "SHA" + KeySize.ToString() evaluates to "SHAS256" (note the "S" in the middle) and subsequently HashAlgorithm.Create(AlgorithmName) evaluates to null because "SHAS256" is not a valid hash algorithm name.

By taking using the numeric value of KeySize (e.g. "SHA" + (int)KeySize) ) , AlgorithmName evaluates to "SHA256" and everything works.